### PR TITLE
Fix the log capturer

### DIFF
--- a/lizard_management_command_runner/log_capturer.py
+++ b/lizard_management_command_runner/log_capturer.py
@@ -12,41 +12,24 @@ from __future__ import division
 """Context manager that helps capturing logging."""
 
 
-import logging
-from StringIO import StringIO
+from io import BytesIO
 
 
-class LogCapturer(object):
-    def __init__(self, buffer=None, format="%(levelname)s: %(message)s"):
-        """It is possible to give an optional buffer, otherwise a fresh one
-        is used. The buffer's contents are accessible afterwards with
-        logcapturer.buffer.getvalue()."""
-        if buffer is None:
-            self.buffer = StringIO()
-        else:
-            self.buffer = buffer
+class StringIOField(object):
+    """
+    Write log to a certain field of a Django model instance. Saves the object
+    on every call to `write`.
+    """
+    def __init__(self, obj, field):
+        self.stream = BytesIO()
+        self.obj = obj
+        self.field = field
 
-        self.format = format
+    def __getattr__(self, item):
+        if item != 'stream':
+            return getattr(self.stream, item)
 
-    def __enter__(self, buffer=None):
-        """Add the new handler."""
-
-        # Create new handler, set its formatter
-        self.logHandler = logging.StreamHandler(self.buffer)
-        formatter = logging.Formatter(self.format)
-        self.logHandler.setFormatter(formatter)
-
-        # Add it
-        rootLogger = logging.getLogger()
-        rootLogger.addHandler(self.logHandler)
-
-        # Returning self makes 'with LogCapturer() as ...' possible.
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        # Remove the handler.
-        rootLogger = logging.getLogger()
-        rootLogger.removeHandler(self.logHandler)
-
-        self.logHandler.flush()
-        self.buffer.flush()  # In case it's something flushable
+    def write(self, *args, **kwargs):
+        self.stream.write(*args, **kwargs)
+        setattr(self.obj, self.field, self.stream.getvalue().decode('utf-8'))
+        self.obj.save()


### PR DESCRIPTION
This updates the appropriate database field on each log `write` call.

Technical note: just subclassing `StringIO` or `BytesIO` does not work.